### PR TITLE
Add tests for IP and port validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ Este proyecto está abierto a contribuciones. Si desea contribuir:
 4. Push a la rama (`git push origin feature/amazing-feature`)
 5. Abra un Pull Request
 
+## 🧪 Tests
+
+Para ejecutar las pruebas unitarias puede utilizar [pytest](https://pytest.org) o
+el módulo integrado de `unittest`:
+
+```bash
+# Con pytest
+pytest
+
+# O con unittest
+python -m unittest discover tests
+```
+
 ## 📄 Licencia
 
 Este proyecto está licenciado bajo la Licencia MIT - vea el archivo [LICENSE](LICENSE) para más detalles.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,39 @@
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from LinuxGuard import validate_ip, validate_port
+
+class TestValidation(unittest.TestCase):
+    def test_validate_ip_valid(self):
+        self.assertTrue(validate_ip('192.168.1.1'))
+        self.assertTrue(validate_ip('0.0.0.0'))
+        self.assertTrue(validate_ip('255.255.255.255'))
+
+    def test_validate_ip_with_cidr(self):
+        self.assertTrue(validate_ip('192.168.0.0/24'))
+        self.assertTrue(validate_ip('10.0.0.0/8'))
+
+    def test_validate_ip_invalid_format(self):
+        self.assertFalse(validate_ip('999.999.999.999'))
+        self.assertFalse(validate_ip('256.256.256.256'))
+        self.assertFalse(validate_ip('1.2.3'))
+        self.assertFalse(validate_ip('abc.def.ghi.jkl'))
+        self.assertFalse(validate_ip('1234.0.0.1'))
+        self.assertFalse(validate_ip('192.168.0.0/33'))
+        self.assertFalse(validate_ip('192.168.0.0/abc'))
+
+    def test_validate_port_valid(self):
+        for port in [1, 22, 80, 65535]:
+            with self.subTest(port=port):
+                self.assertTrue(validate_port(port))
+
+    def test_validate_port_invalid(self):
+        for port in [0, -1, 65536, 'abc', '']: 
+            with self.subTest(port=port):
+                self.assertFalse(validate_port(port))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests for `validate_ip` and `validate_port`
- mention how to run tests in README

## Testing
- `pytest -q`
- `python -m unittest discover tests`


------
https://chatgpt.com/codex/tasks/task_e_684dbe6228a48333a106a45595896934